### PR TITLE
Use deps.ts instead of import maps

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,3 @@
 {
     "deno.enable": true,
-    "deno.import_map": "./import_map.json"
 }

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 run:
 	deno \
-		--importmap=import_map.json \
 		--allow-net \
 		--allow-read \
 		index.ts \

--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ dencro [directory] [options]
 
 - `[directory]` - directory which you want to serve
 - `[options]` - Aditional options
-  - `--port` - set the port on which to serve
+  - `--port` - set the port on which to serve. Default: `8080`
 
 **Example:**
 
 ```sh
-~ dencro . --port 8080
+~ dencro .
 Serving files from: ~
 Listening at http://localhost:8080/
 ```

--- a/README.md
+++ b/README.md
@@ -13,8 +13,12 @@ deno install -n dencro --allow-net --allow-read https://raw.githubusercontent.co
 ## Usage
 
 ```sh
-dencro <directoryToServeFiles> [--port 8080]
+dencro [directory] [options]
 ```
+
+- `[directory]` - directory which you want to serve
+- `[options]` - Aditional options
+  - `--port` - set the port on which to serve
 
 **Example:**
 
@@ -26,13 +30,13 @@ Listening at http://localhost:8080/
 
 ## Development
 
--   Clone the repo:
+- Clone the repo:
 
 ```sh
 git clone https://github.com/hswolff/dencro.git
 ```
 
--   run dencro:
+- run dencro:
 
 ```sh
 deno run --allow-net --allow-read index.ts <directoryToServeFiles> [--port 8080]

--- a/README.md
+++ b/README.md
@@ -4,10 +4,38 @@ an adaptation of [micro](https://github.com/zeit/micro) for [deno](https://deno.
 
 Except this one will serve any handlers it finds on the file system that mirror the request.
 
+## Install
+
+```sh
+deno install -n dencro --allow-net --allow-read https://raw.githubusercontent.com/hswolff/dencro/master/index.ts
+```
+
 ## Usage
 
 ```sh
-deno --allow-net --allow-read index.ts <directoryToServeFiles> [--port 8080]
+dencro <directoryToServeFiles> [--port 8080]
+```
+
+**Example:**
+
+```sh
+~ dencro . --port 8080
+Serving files from: ~
+Listening at http://localhost:8080/
+```
+
+## Development
+
+-   Clone the repo:
+
+```sh
+git clone https://github.com/hswolff/dencro.git
+```
+
+-   run dencro:
+
+```sh
+deno run --allow-net --allow-read index.ts <directoryToServeFiles> [--port 8080]
 ```
 
 ## Todo

--- a/deps.ts
+++ b/deps.ts
@@ -1,6 +1,3 @@
-export {
-  serve,
-  ServerRequest
-} from "https://deno.land/std/http/server.ts";
+export { serve, ServerRequest } from "https://deno.land/std/http/server.ts";
 export { parse } from "https://deno.land/std/flags/mod.ts";
 export { red, green } from "https://deno.land/std/fmt/colors.ts";

--- a/deps.ts
+++ b/deps.ts
@@ -1,0 +1,6 @@
+export {
+  serve,
+  ServerRequest
+} from "https://deno.land/std/http/server.ts";
+export { parse } from "https://deno.land/std/flags/mod.ts";
+export { red, green } from "https://deno.land/std/fmt/colors.ts";

--- a/deps.ts
+++ b/deps.ts
@@ -1,3 +1,3 @@
-export { serve, ServerRequest } from "https://deno.land/std/http/server.ts";
-export { parse } from "https://deno.land/std/flags/mod.ts";
-export { red, green } from "https://deno.land/std/fmt/colors.ts";
+export { serve, ServerRequest } from "https://deno.land/std@0.52.0/http/server.ts";
+export { parse } from "https://deno.land/std@0.52.0/flags/mod.ts";
+export { red, green } from "https://deno.land/std@0.52.0/fmt/colors.ts";

--- a/example/about.ts
+++ b/example/about.ts
@@ -1,4 +1,4 @@
-import { ServerRequest } from "https://deno.land/std@v0.35.0/http/server.ts";
+import { ServerRequest } from "https://deno.land/std/http/server.ts";
 export default (req: ServerRequest) => {
   return `What is this about??\n${req.url}`;
 };

--- a/example/hello/greeting.ts
+++ b/example/hello/greeting.ts
@@ -1,4 +1,4 @@
-import { ServerRequest } from "https://deno.land/std@v0.35.0/http/server.ts";
+import { ServerRequest } from "https://deno.land/std/http/server.ts";
 export default (req: ServerRequest) => {
   return `Greetings people!!!\n${req.url}`;
 };

--- a/example/hello/index.ts
+++ b/example/hello/index.ts
@@ -1,4 +1,4 @@
-import { ServerRequest } from "https://deno.land/std@v0.35.0/http/server.ts";
+import { ServerRequest } from "https://deno.land/std/http/server.ts";
 export default (req: ServerRequest) => {
   return `Hello to whee!!\n${req.url}`;
 };

--- a/example/index.ts
+++ b/example/index.ts
@@ -1,4 +1,4 @@
-import { ServerRequest } from "https://deno.land/std@v0.35.0/http/server.ts";
+import { ServerRequest } from "https://deno.land/std/http/server.ts";
 export default (req: ServerRequest) => {
   return `Soooo small!!\n${req.url}`;
 };

--- a/import_map.json
+++ b/import_map.json
@@ -1,7 +1,0 @@
-{
-  "imports": {
-    "http/": "https://deno.land/std@v0.35.0/http/",
-    "fmt/": "https://deno.land/std@v0.35.0/fmt/",
-    "flags/": "https://deno.land/std@v0.35.0/flags/"
-  }
-}

--- a/index.ts
+++ b/index.ts
@@ -3,8 +3,8 @@ import { serve, ServerRequest, parse, red, green } from "./deps.ts";
 async function createServer() {
   const args = parse(Deno.args, {
     default: {
-      port: 8080
-    }
+      port: 8080,
+    },
   });
 
   // Allow a user to set what directory to serve files from
@@ -26,7 +26,7 @@ async function createServer() {
   for await (const req of s) {
     if (req.url.endsWith("favicon.ico")) {
       req.respond({
-        status: 200
+        status: 200,
       });
       continue;
     }
@@ -39,7 +39,7 @@ async function createServer() {
     } catch (error) {
       req.respond({
         status: 404,
-        body: `Error: No handler for ${req.url}`
+        body: `Error: No handler for ${req.url}`,
       });
       logRequest(false);
       continue;
@@ -49,14 +49,14 @@ async function createServer() {
       const handler = await import(handlerPath);
 
       req.respond({
-        body: handler.default(req)
+        body: handler.default(req),
       });
 
       logRequest(true);
     } catch {
       req.respond({
         status: 500,
-        body: `Error: Unable to parse handler at ${req.url}`
+        body: `Error: Unable to parse handler at ${req.url}`,
       });
       logRequest(false);
     }

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-import * from "./deps.ts";
+import { serve, ServerRequest, parse, red, green } from "./deps.ts";
 
 async function createServer() {
   const args = parse(Deno.args, {
@@ -11,7 +11,7 @@ async function createServer() {
   if (args._.length === 1) {
     const directoryArg = args._[0];
     try {
-      const fullPath = await Deno.realpath(directoryArg);
+      const fullPath = await Deno.realPath(String(directoryArg));
       Deno.chdir(fullPath);
     } catch (error) {
       console.error(red(`Unable to serve files from: ${directoryArg}`));
@@ -73,9 +73,9 @@ export async function getHandlerPath(requestUrl: string): Promise<string> {
 
   let result;
   try {
-    result = await Deno.realpath("." + requestAsFile + ".ts");
+    result = await Deno.realPath("." + requestAsFile + ".ts");
   } catch {
-    result = await Deno.realpath("." + `${requestUrl}/index` + ".ts");
+    result = await Deno.realPath("." + `${requestUrl}/index` + ".ts");
   }
 
   return result;

--- a/index.ts
+++ b/index.ts
@@ -34,6 +34,7 @@ async function createServer() {
     const logRequest = createLogRequest(req);
 
     let handlerPath;
+
     try {
       handlerPath = await getHandlerPath(req.url);
     } catch (error) {
@@ -62,6 +63,7 @@ async function createServer() {
     }
   }
 }
+
 if (import.meta.main) {
   createServer();
 }

--- a/index.ts
+++ b/index.ts
@@ -1,9 +1,4 @@
-import {
-  serve,
-  ServerRequest
-} from "http/server.ts";
-import { parse } from "flags/mod.ts";
-import { red, green } from "fmt/colors.ts";
+import * from "./deps.ts";
 
 async function createServer() {
   const args = parse(Deno.args, {


### PR DESCRIPTION
As stated in the deno [docs/linking_to_external_code](https://github.com/denoland/deno/blob/master/docs/linking_to_external_code.md), the "official" way to conveniently import multiple dependencies is to use `deps.ts`.