### PR TITLE
switch to "deps.ts" + Updated README.md

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,3 @@
 {
     "deno.enable": true,
-    "deno.import_map": "./import_map.json"
 }

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 run:
 	deno \
-		--importmap=import_map.json \
 		--allow-net \
 		--allow-read \
 		index.ts \

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ git clone https://github.com/hswolff/dencro.git
 deno run --allow-net --allow-read index.ts <directoryToServeFiles> [--port 8080]
 ```
 
+**Note:** Make sure to format everything using the `deno fmt` command before pushing the changes.
+
 ## Todo
 
 - [x] Add [command line argument parsing](https://deno.land/std/flags/)

--- a/README.md
+++ b/README.md
@@ -4,10 +4,42 @@ an adaptation of [micro](https://github.com/zeit/micro) for [deno](https://deno.
 
 Except this one will serve any handlers it finds on the file system that mirror the request.
 
+## Install
+
+```sh
+deno install -n dencro --allow-net --allow-read https://raw.githubusercontent.com/hswolff/dencro/master/index.ts
+```
+
 ## Usage
 
 ```sh
-deno --allow-net --allow-read index.ts <directoryToServeFiles> [--port 8080]
+dencro [directory] [options]
+```
+
+- `[directory]` - directory which you want to serve
+- `[options]` - Aditional options
+  - `--port` - set the port on which to serve. Default: `8080`
+
+**Example:**
+
+```sh
+~ dencro .
+Serving files from: ~
+Listening at http://localhost:8080/
+```
+
+## Development
+
+- Clone the repo:
+
+```sh
+git clone https://github.com/hswolff/dencro.git
+```
+
+- run dencro:
+
+```sh
+deno run --allow-net --allow-read index.ts <directoryToServeFiles> [--port 8080]
 ```
 
 ## Todo

--- a/deps.ts
+++ b/deps.ts
@@ -1,0 +1,6 @@
+export {
+  serve,
+  ServerRequest,
+} from "https://deno.land/std@0.52.0/http/server.ts";
+export { parse } from "https://deno.land/std@0.52.0/flags/mod.ts";
+export { red, green } from "https://deno.land/std@0.52.0/fmt/colors.ts";

--- a/import_map.json
+++ b/import_map.json
@@ -1,7 +1,0 @@
-{
-  "imports": {
-    "http/": "https://deno.land/std/http/",
-    "fmt/": "https://deno.land/std/fmt/",
-    "flags/": "https://deno.land/std/flags/"
-  }
-}

--- a/index.ts
+++ b/index.ts
@@ -3,89 +3,91 @@ import { parse } from "flags/mod.ts";
 import { red, green } from "fmt/colors.ts";
 
 async function createServer() {
-    const args = parse(Deno.args, {
-        default: {
-            port: 8080,
-        },
-    });
+  const args = parse(Deno.args, {
+    default: {
+      port: 8080,
+    },
+  });
 
-    // Allow a user to set what directory to serve files from
-    if (args._.length === 1) {
-        const directoryArg = args._[0];
-        try {
-            const fullPath = await Deno.realPath(String(directoryArg));
-            Deno.chdir(fullPath);
-        } catch (error) {
-            console.error(red(`Unable to serve files from: ${directoryArg}`));
-        }
+  // Allow a user to set what directory to serve files from
+  if (args._.length === 1) {
+    const directoryArg = args._[0];
+    try {
+      const fullPath = await Deno.realPath(String(directoryArg));
+      Deno.chdir(fullPath);
+    } catch (error) {
+      console.error(red(`Unable to serve files from: ${directoryArg}`));
+    }
+  }
+
+  console.log("Serving files from:", Deno.cwd());
+
+  const s = serve({ port: args.port });
+  console.log(`Listening at http://localhost:${args.port}/`);
+
+  for await (const req of s) {
+    if (req.url.endsWith("favicon.ico")) {
+      req.respond({
+        status: 200,
+      });
+      continue;
     }
 
-    console.log("Serving files from:", Deno.cwd());
+    const logRequest = createLogRequest(req);
 
-    const s = serve({ port: args.port });
-    console.log(`Listening at http://localhost:${args.port}/`);
-
-    for await (const req of s) {
-        if (req.url.endsWith("favicon.ico")) {
-            req.respond({
-                status: 200,
-            });
-            continue;
-        }
-
-        const logRequest = createLogRequest(req);
-
-        let handlerPath;
-        try {
-            handlerPath = await getHandlerPath(req.url);
-        } catch (error) {
-            req.respond({
-                status: 404,
-                body: `Error: No handler for ${req.url}`,
-            });
-            logRequest(false);
-            continue;
-        }
-
-        try {
-            const handler = await import(handlerPath);
-
-            req.respond({
-                body: handler.default(req),
-            });
-
-            logRequest(true);
-        } catch {
-            req.respond({
-                status: 500,
-                body: `Error: Unable to parse handler at ${req.url}`,
-            });
-            logRequest(false);
-        }
+    let handlerPath;
+    try {
+      handlerPath = await getHandlerPath(req.url);
+    } catch (error) {
+      req.respond({
+        status: 404,
+        body: `Error: No handler for ${req.url}`,
+      });
+      logRequest(false);
+      continue;
     }
+
+    try {
+      const handler = await import(handlerPath);
+
+      req.respond({
+        body: handler.default(req),
+      });
+
+      logRequest(true);
+    } catch {
+      req.respond({
+        status: 500,
+        body: `Error: Unable to parse handler at ${req.url}`,
+      });
+      logRequest(false);
+    }
+  }
 }
 if (import.meta.main) {
-    createServer();
+  createServer();
 }
 
 export async function getHandlerPath(requestUrl: string): Promise<string> {
-    const requestAsFile = requestUrl.endsWith("/") ? `${requestUrl}index` : requestUrl;
+  const requestAsFile = requestUrl.endsWith("/")
+    ? `${requestUrl}index`
+    : requestUrl;
 
-    let result;
-    try {
-        result = await Deno.realPath("." + requestAsFile + ".ts");
-    } catch {
-        result = await Deno.realPath("." + `${requestUrl}/index` + ".ts");
-    }
+  let result;
+  try {
+    result = await Deno.realPath("." + requestAsFile + ".ts");
+  } catch {
+    result = await Deno.realPath("." + `${requestUrl}/index` + ".ts");
+  }
 
-    return result;
+  return result;
 }
 
 function createLogRequest(req: ServerRequest): (success: boolean) => void {
-    const start = performance.now();
-    return (success = true) => {
-        const end = performance.now();
-        const msg = `${req.url} in ${end - start}ms`;
-        console.log(success ? green(msg) : red(msg));
-    };
+  const start = performance.now();
+  return (success = true) => {
+    const end = performance.now();
+    const msg = `${req.url} in ${end - start}ms`;
+    console.log(success ? green(msg) : red(msg));
+  };
 }

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,4 @@
-import { serve, ServerRequest } from "http/server.ts";
-import { parse } from "flags/mod.ts";
-import { red, green } from "fmt/colors.ts";
+import { serve, ServerRequest, parse, red, green } from "./deps.ts";
 
 async function createServer() {
   const args = parse(Deno.args, {


### PR DESCRIPTION
As stated in [docs/linking_to_external_code](https://github.com/denoland/deno/blob/master/docs/linking_to_external_code.md#it-seems-unwieldy-to-import-urls-everywhere),  `deps.ts` is the preferred way of importing dependencies conveniently.

The older pull request(#4) had some merge conflicts that could not be fixed easily, so I am opening this new pull request fixing the same problems.

---

I'm really sorry for your live stream. The conflicting pull request already had the fixes from the one  that you merged. That means you should have merged the other one.

> Why did you not tell me this earlier?

Because I forgot to close the older PR and also I live on the other side of the globe, so I couldn't tell you while the live stream.